### PR TITLE
Remove needless quote

### DIFF
--- a/repeat-help.el
+++ b/repeat-help.el
@@ -85,8 +85,8 @@ latter will fall back on the echo area message built into
 `repeat-mode'."
   :group 'repeat-help
   :type '(choice
-          (const :tag "Embark indicator" 'embark)
-          (const :tag "Which Key indicator" 'which-key)
+          (const :tag "Embark indicator" embark)
+          (const :tag "Which Key indicator" which-key)
           (const :tag "Default indicator" t)))
 
 ;; Choose between Embark and Which Key when dispatching


### PR DESCRIPTION
This fixes the following byte-compile warning on development Emacs(29.0.50)

```
repeat-help.el:77:12: Warning: defcustom for ‘repeat-help-popup-type’ has
    syntactically odd type ‘'(choice (const :tag Embark indicator 'embark)
    (const :tag Which Key indicator 'which-key) (const :tag Default indicator
    t))’
```